### PR TITLE
metrc: rename posts in locations and strains

### DIFF
--- a/locations.go
+++ b/locations.go
@@ -95,9 +95,9 @@ func (m *Metrc) GetLocationsTypes(licenseNumber *string) ([]LocationGet, error) 
 	return lr, nil
 }
 
-// CreateLocations creates new locations.
+// PostLocationsCreate creates new locations.
 // See: https://api-ca.metrc.com/Documentation/#Locations.post_locations_v1_create
-func (m *Metrc) CreateLocations(locs []LocationPost, licenseNumber *string) ([]byte, error) {
+func (m *Metrc) PostLocationsCreate(locs []LocationPost, licenseNumber *string) ([]byte, error) {
 	endpoint := fmt.Sprintf("locations/v1/create")
 
 	if licenseNumber != nil {
@@ -117,9 +117,9 @@ func (m *Metrc) CreateLocations(locs []LocationPost, licenseNumber *string) ([]b
 	return resp, nil
 }
 
-// UpdateLocations updates existing Locations. Note that for this endpoint, `LocationPost.Id` is required in each `LocationPost` in the input slice.
+// PostLocationsUpdate updates existing Locations. Note that for this endpoint, `LocationPost.Id` is required in each `LocationPost` in the input slice.
 // See: https://api-ca.metrc.com/Documentation/#Locations.post_locations_v1_update
-func (m *Metrc) UpdateLocations(locs []LocationPost, licenseNumber *string) ([]byte, error) {
+func (m *Metrc) PostLocationsUpdate(locs []LocationPost, licenseNumber *string) ([]byte, error) {
 	endpoint := "locations/v1/update"
 	if licenseNumber != nil {
 		endpoint += fmt.Sprintf("?licenseNumber=%s", *licenseNumber)

--- a/locations_test.go
+++ b/locations_test.go
@@ -59,7 +59,7 @@ func TestLocationsCreateUpdateDelete_Integration(t *testing.T) {
 			TypeName: "Default Location Type",
 		},
 	}
-	_, err := m.CreateLocations(locs, &licenseNumber)
+	_, err := m.PostLocationsCreate(locs, &licenseNumber)
 	assert.NoError(t, err)
 
 	// Get all active Locations, and then find the Id of the new Location.
@@ -81,7 +81,7 @@ func TestLocationsCreateUpdateDelete_Integration(t *testing.T) {
 			TypeName: "Default Location Type",
 		},
 	}
-	_, err = m.UpdateLocations(locs, &licenseNumber)
+	_, err = m.PostLocationsUpdate(locs, &licenseNumber)
 	assert.NoError(t, err)
 
 	// Delete the Location using the ID.

--- a/strains.go
+++ b/strains.go
@@ -61,9 +61,9 @@ func (m *Metrc) GetStrainsActive(licenseNumber *string) ([]Strain, error) {
 	return sr, nil
 }
 
-// CreateStrains creates new Strains.
+// PostStrainsCreate creates new Strains.
 // See: https://api-ca.metrc.com/Documentation/#Strains.post_strains_v1_create
-func (m *Metrc) CreateStrains(strains []Strain, licenseNumber *string) ([]byte, error) {
+func (m *Metrc) PostStrainsCreate(strains []Strain, licenseNumber *string) ([]byte, error) {
 	endpoint := "strains/v1/create"
 	if licenseNumber != nil {
 		endpoint += fmt.Sprintf("?licenseNumber=%s", *licenseNumber)
@@ -82,9 +82,9 @@ func (m *Metrc) CreateStrains(strains []Strain, licenseNumber *string) ([]byte, 
 	return resp, nil
 }
 
-// UpdateStrains updates existing Strains.
+// PostStrainsUpdate updates existing Strains.
 // See: https://api-ca.metrc.com/Documentation/#Strains.post_strains_v1_update
-func (m *Metrc) UpdateStrains(strains []Strain, licenseNumber *string) ([]byte, error) {
+func (m *Metrc) PostStrainsUpdate(strains []Strain, licenseNumber *string) ([]byte, error) {
 	endpoint := "strains/v1/update"
 	if licenseNumber != nil {
 		endpoint += fmt.Sprintf("?licenseNumber=%s", *licenseNumber)

--- a/strains_test.go
+++ b/strains_test.go
@@ -44,7 +44,7 @@ func TestStrainsCreateUpdateDelete_Integration(t *testing.T) {
 			SativaPercentage: 75.0,
 		},
 	}
-	_, err := m.CreateStrains(strains, &licenseNumber)
+	_, err := m.PostStrainsCreate(strains, &licenseNumber)
 	assert.NoError(t, err)
 
 	// Get all active Strains, and then find the Id of the new Strain.

--- a/strains_test.go
+++ b/strains_test.go
@@ -70,6 +70,6 @@ func TestStrainsCreateUpdateDelete_Integration(t *testing.T) {
 			SativaPercentage: 75.0,
 		},
 	}
-	_, err = m.UpdateStrains(strains, &licenseNumber)
+	_, err = m.PostStrainsUpdate(strains, &licenseNumber)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Renames POST functions in locations and strains.