### PR TITLE
metrc: add vendor and user keys as client args

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,14 +23,18 @@ type ClientInterface interface {
 // HttpClient is a convenience client for raw HTTP calls.
 // Wraps a generic `http.Client` and implements `ClientInterface`.
 type HttpClient struct {
-	client *http.Client
+	client    *http.Client
+	vendorKey string
+	userKey   string
 }
 
 // MakeHttpClient lets external packages generate a wrapped HTTP client.
 // This exposes the internals used to call Metrc.
-func MakeHttpClient() *HttpClient {
+func MakeHttpClient(vendorKey string, userKey string) *HttpClient {
 	return &HttpClient{
-		client: &http.Client{},
+		client:    &http.Client{},
+		vendorKey: vendorKey,
+		userKey:   userKey,
 	}
 }
 
@@ -79,7 +83,7 @@ func (c *HttpClient) Put(endpoint string, body []byte) ([]byte, error) {
 
 // do is a boilerplate funtion that executes a request and returns a response.
 func (c *HttpClient) do(req *http.Request) ([]byte, error) {
-	req.SetBasicAuth(vendorKey, userKey)
+	req.SetBasicAuth(c.vendorKey, c.userKey)
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,7 @@ import (
 
 // TODO: Think about a testing strategy for the client that doesn't require Metrc calls.
 // At its core we want to confirm that we can make requests that have the basic auth header.
-var hc *HttpClient = MakeHttpClient()
+var hc *HttpClient = MakeHttpClient(vendorKey, userKey)
 
 func TestHttpClientGet(t *testing.T) {
 	endpoint := "facilities/v1"

--- a/facilities_test.go
+++ b/facilities_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var m *Metrc = MakeIntegrationMetrc()
+var m *Metrc = MakeIntegrationMetrc(vendorKey, userKey)
 
 func TestFacilities_Integration(t *testing.T) {
 	resp, err := m.Facilities()

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/metrc.go
+++ b/metrc.go
@@ -70,8 +70,8 @@ type MetrcInterface interface {
 	GetUnitsOfMeasure() ([]UnitsOfMeasure, error)
 }
 
-func MakeIntegrationMetrc() *Metrc {
-	var ci ClientInterface = MakeHttpClient()
+func MakeIntegrationMetrc(vendorKey string, userKey string) *Metrc {
+	var ci ClientInterface = MakeHttpClient(vendorKey, userKey)
 	return &Metrc{
 		client: ci,
 	}


### PR DESCRIPTION
This adds the vendor and user keys as arguments to the custom HTTP client. We replace hardcoding the vendor and user keys for our personal sandbox. This lets different users use this tooling. 