### PR TITLE
rename endpoints to front-load the action

### DIFF
--- a/items.go
+++ b/items.go
@@ -174,9 +174,9 @@ func (m *Metrc) GetItemsCategories(licenseNumber *string) ([]ItemCategory, error
 	return ic, nil
 }
 
-// CreateItems creates new Items.
+// PostItemsCreate creates new Items.
 // See: https://api-ca.metrc.com/Documentation/#Items.post_items_v1_create
-func (m *Metrc) CreateItems(items []ItemPost, licenseNumber *string) ([]byte, error) {
+func (m *Metrc) PostItemsCreate(items []ItemPost, licenseNumber *string) ([]byte, error) {
 	endpoint := "items/v1/create"
 	if licenseNumber != nil {
 		endpoint += fmt.Sprintf("?licenseNumber=%s", *licenseNumber)
@@ -195,9 +195,9 @@ func (m *Metrc) CreateItems(items []ItemPost, licenseNumber *string) ([]byte, er
 	return resp, nil
 }
 
-// UpdateItems updates existing Items. Note that for this endpoint, `ItemPost.Id` is required in each `ItemPost` in the input slice.
+// PostItemsUpdate updates existing Items. Note that for this endpoint, `ItemPost.Id` is required in each `ItemPost` in the input slice.
 // See: https://api-ca.metrc.com/Documentation/#Items.post_items_v1_update
-func (m *Metrc) UpdateItems(items []ItemPost, licenseNumber *string) ([]byte, error) {
+func (m *Metrc) PostItemsUpdate(items []ItemPost, licenseNumber *string) ([]byte, error) {
 	endpoint := "items/v1/update"
 	if licenseNumber != nil {
 		endpoint += fmt.Sprintf("?licenseNumber=%s", *licenseNumber)

--- a/items_test.go
+++ b/items_test.go
@@ -71,7 +71,7 @@ func TestItemsCreateUpdateDelete_Integration(t *testing.T) {
 		NumberOfDoses:                   2,
 	}
 	items := []ItemPost{item}
-	_, err := m.CreateItems(items, &licenseNumber)
+	_, err := m.PostItemsCreate(items, &licenseNumber)
 	assert.NoError(t, err)
 
 	// Get all active Items, and then find the Id of the new Item.
@@ -89,7 +89,7 @@ func TestItemsCreateUpdateDelete_Integration(t *testing.T) {
 	item.Id = itemId
 	item.Name = fmt.Sprintf("%d", rand.Int())
 	items = []ItemPost{item}
-	_, err = m.UpdateItems(items, &licenseNumber)
+	_, err = m.PostItemsUpdate(items, &licenseNumber)
 	assert.NoError(t, err)
 
 	// Delete the Item using the ID.

--- a/metrc.go
+++ b/metrc.go
@@ -15,16 +15,16 @@ type MetrcInterface interface {
 	GetItemsById(id int, licenseNumber *string) (ItemGet, error)
 	GetItemsActive(licenseNumber *string) ([]ItemGet, error)
 	GetItemsCategories(licenseNumber *string) ([]ItemCategory, error)
-	CreateItems(items []ItemPost, licenseNumber *string) ([]byte, error)
-	UpdateItems(items []ItemPost, licenseNumber *string) ([]byte, error)
+	PostItemsCreate(items []ItemPost, licenseNumber *string) ([]byte, error)
+	PostItemsUpdate(items []ItemPost, licenseNumber *string) ([]byte, error)
 	DeleteItemById(id int, licenseNumber *string) ([]byte, error)
 
 	// locations
 	GetLocationsById(id int, licenseNumber *string) (LocationGet, error)
 	GetLocationsActive(licenseNumber *string) ([]LocationGet, error)
 	GetLocationsTypes(licenseNumber *string) ([]LocationGet, error)
-	CreateLocations(locs []LocationPost, licenseNumber *string) ([]byte, error)
-	UpdateLocations(locs []LocationPost, licenseNumber *string) ([]byte, error)
+	PostLocationsCreate(locs []LocationPost, licenseNumber *string) ([]byte, error)
+	PostLocationsUpdate(locs []LocationPost, licenseNumber *string) ([]byte, error)
 	DeleteLocationById(id int, licenseNumber *string) ([]byte, error)
 
 	// packages
@@ -35,9 +35,9 @@ type MetrcInterface interface {
 	GetPackagesInactive(licenseNumber string, lastModifiedStart *string, lastModifiedEnd *string) ([]PackageGet, error)
 	GetPackagesTypes() ([]string, error)
 	GetPackagesAdjustReasons(licenseNumber string) ([]PackageAdjustReasons, error)
-	CreatePackages(packages []PackagePost, licenseNumber string) ([]byte, error)
-	CreatePackagesTesting(packages []PackagePost, licenseNumber string) ([]byte, error)
-	CreatePackagesPlantings(packages []PackagePost, licenseNumber string) ([]byte, error)
+	PostPackagesCreate(packages []PackagePost, licenseNumber string) ([]byte, error)
+	PostPackagesCreateTesting(packages []PackagePost, licenseNumber string) ([]byte, error)
+	PostPackagesCreatePlanting(packages []PackagePost, licenseNumber string) ([]byte, error)
 	ChangePackagesItem(packageItems []PackageItem, licenseNumber string) ([]byte, error)
 	ChangePackagesNote(packageNotes []PackageNote, licenseNumber string) ([]byte, error)
 	ChangePackagesLocations(packageLocations []PackageLocation, licenseNumber string) ([]byte, error)
@@ -62,8 +62,8 @@ type MetrcInterface interface {
 	// strains
 	GetStrainsById(id int, licenseNumber *string) (Strain, error)
 	GetStrainsActive(licenseNumber *string) ([]Strain, error)
-	CreateStrains(strains []Strain, licenseNumber *string) ([]byte, error)
-	UpdateStrains(strains []Strain, licenseNumber *string) ([]byte, error)
+	PostStrainsCreate(strains []Strain, licenseNumber *string) ([]byte, error)
+	PostStrainsUpdate(strains []Strain, licenseNumber *string) ([]byte, error)
 	DeleteStrainById(id int, licenseNumber *string) ([]byte, error)
 
 	// units of measure

--- a/packages.go
+++ b/packages.go
@@ -226,9 +226,9 @@ func (m *Metrc) GetPackagesAdjustReasons(licenseNumber string) ([]PackageAdjustR
 	return par, nil
 }
 
-// CreatePackages creates new Packages.
+// PostPackagesCreate creates new Packages.
 // See: https://api-ca.metrc.com/Documentation/#Packages.post_packages_v1_create
-func (m *Metrc) CreatePackages(packages []PackagePost, licenseNumber string) ([]byte, error) {
+func (m *Metrc) PostPackagesCreate(packages []PackagePost, licenseNumber string) ([]byte, error) {
 	endpoint := fmt.Sprintf("packages/v1/create?licenseNumber=%s", licenseNumber)
 
 	body, err := json.Marshal(packages)
@@ -244,9 +244,9 @@ func (m *Metrc) CreatePackages(packages []PackagePost, licenseNumber string) ([]
 	return resp, nil
 }
 
-// CreatePackagesTesting creates Packages for testing.
+// PostPackagesCreateTesting creates Packages for testing.
 // See: https://api-ca.metrc.com/Documentation/#Packages.post_packages_v1_create_testing
-func (m *Metrc) CreatePackagesTesting(packages []PackagePost, licenseNumber string) ([]byte, error) {
+func (m *Metrc) PostPackagesCreateTesting(packages []PackagePost, licenseNumber string) ([]byte, error) {
 	endpoint := fmt.Sprintf("packages/v1/create/testing?licenseNumber=%s", licenseNumber)
 
 	body, err := json.Marshal(packages)
@@ -261,9 +261,9 @@ func (m *Metrc) CreatePackagesTesting(packages []PackagePost, licenseNumber stri
 	return resp, nil
 }
 
-// CreatePackagesPlanting creates Packages from Planting.
+// PostPackagesCreatePlanting creates Packages from Planting.
 // See: https://api-ca.metrc.com/Documentation/#Packages.post_packages_v1_create_plantings
-func (m *Metrc) CreatePackagesPlantings(packages []PackagePost, licenseNumber string) ([]byte, error) {
+func (m *Metrc) PostPackagesCreatePlantings(packages []PackagePost, licenseNumber string) ([]byte, error) {
 	endpoint := fmt.Sprintf("packages/v1/create/plantings?licenseNumber=%s", licenseNumber)
 
 	body, err := json.Marshal(packages)
@@ -285,9 +285,9 @@ type PackageItem struct {
 	Item  string `json:"Item"`
 }
 
-// ChangePackagesItem changes the Item on a Package.
+// PostPackagesChangeItem changes the Item on a Package.
 // See: https://api-ca.metrc.com/Documentation/#Packages.post_packages_v1_change_item
-func (m *Metrc) ChangePackagesItem(packageItems []PackageItem, licenseNumber string) ([]byte, error) {
+func (m *Metrc) PostPackagesChangeItem(packageItems []PackageItem, licenseNumber string) ([]byte, error) {
 	endpoint := fmt.Sprintf("packages/v1/change/item?licenseNumber=%s", licenseNumber)
 
 	body, err := json.Marshal(packageItems)
@@ -310,9 +310,9 @@ type PackageNote struct {
 	Note  string `json:"Note"`
 }
 
-// ChangePackagesNote changes the Note on a Package.
+// PutPackagesChangeNote changes the Note on a Package.
 // See: https://api-ca.metrc.com/Documentation/#Packages.put_packages_v1_change_note
-func (m *Metrc) ChangePackagesNote(packageNotes []PackageNote, licenseNumber string) ([]byte, error) {
+func (m *Metrc) PutPackagesChangeNote(packageNotes []PackageNote, licenseNumber string) ([]byte, error) {
 	endpoint := fmt.Sprintf("packages/v1/change/note?licenseNumber=%s", licenseNumber)
 
 	body, err := json.Marshal(packageNotes)
@@ -336,9 +336,9 @@ type PackageLocation struct {
 	MoveDate string `json:"MoveDate"`
 }
 
-// ChangePackagesLocation changes the Location on a Package.
+// PostPackagesChangeLocations changes the Location on a Package.
 // See: https://api-ca.metrc.com/Documentation/#Packages.post_packages_v1_change_locations
-func (m *Metrc) ChangePackagesLocations(packageLocations []PackageLocation, licenseNumber string) ([]byte, error) {
+func (m *Metrc) PostPackagesChangeLocations(packageLocations []PackageLocation, licenseNumber string) ([]byte, error) {
 	endpoint := fmt.Sprintf("packages/v1/change/locations?licenseNumber=%s", licenseNumber)
 
 	body, err := json.Marshal(packageLocations)
@@ -365,9 +365,9 @@ type PackageAdjust struct {
 	ReasonNote       *string `json:"ReasonNote"`
 }
 
-// AdjustPackages changes adjustment metadata on a Package.
+// PostPackagesAdjust changes adjustment metadata on a Package.
 // See: https://api-ca.metrc.com/Documentation/#Packages.post_packages_v1_adjust
-func (m *Metrc) AdjustPackages(packageAdjusts []PackageAdjust, licenseNumber string) ([]byte, error) {
+func (m *Metrc) PostPackagesAdjust(packageAdjusts []PackageAdjust, licenseNumber string) ([]byte, error) {
 	endpoint := fmt.Sprintf("packages/v1/adjust?licenseNumber=%s", licenseNumber)
 
 	body, err := json.Marshal(packageAdjusts)
@@ -390,9 +390,9 @@ type PackageFinish struct {
 	ActualDate string `json:"ActualDate"`
 }
 
-// FinishPackages finishes a Package.
+// PostPackagesFinish finishes a Package.
 // See: https://api-ca.metrc.com/Documentation/#Packages.post_packages_v1_finish
-func (m *Metrc) FinishPackages(packageFinishes []PackageFinish, licenseNumber string) ([]byte, error) {
+func (m *Metrc) PostPackagesFinish(packageFinishes []PackageFinish, licenseNumber string) ([]byte, error) {
 	endpoint := fmt.Sprintf("packages/v1/finish?licenseNumber=%s", licenseNumber)
 
 	body, err := json.Marshal(packageFinishes)
@@ -414,9 +414,9 @@ type PackageUnfinish struct {
 	Label string `json:"Label"`
 }
 
-// UnfinishPackages unfinishes Packages.
+// PostPackagesUnfinish unfinishes Packages.
 // See: https://api-ca.metrc.com/Documentation/#Packages.post_packages_v1_unfinish
-func (m *Metrc) UnfinishPackages(packageUnfinishes []PackageUnfinish, licenseNumber string) ([]byte, error) {
+func (m *Metrc) PostPackagesUnfinish(packageUnfinishes []PackageUnfinish, licenseNumber string) ([]byte, error) {
 	endpoint := fmt.Sprintf("packages/v1/unfinish?licenseNumber=%s", licenseNumber)
 
 	body, err := json.Marshal(packageUnfinishes)
@@ -441,9 +441,9 @@ type PackageRemediate struct {
 	Steps      string `json:"RemediationSteps"`
 }
 
-// RemediatePackages remediates Packages.
+// PostPackagesRemediate remediates Packages.
 // See: https://api-ca.metrc.com/Documentation/#Packages.post_packages_v1_remediate
-func (m *Metrc) RemediatePackages(packageRemediates []PackageRemediate, licenseNumber string) ([]byte, error) {
+func (m *Metrc) PostPackagesRemediate(packageRemediates []PackageRemediate, licenseNumber string) ([]byte, error) {
 	endpoint := fmt.Sprintf("packages/v1/remediate?licenseNumber=%s", licenseNumber)
 
 	body, err := json.Marshal(packageRemediates)

--- a/packages_test.go
+++ b/packages_test.go
@@ -88,7 +88,7 @@ func TestPackagesCreate_Integration(t *testing.T) {
 		},
 	}
 	packages := []PackagePost{wantPackage}
-	_, err := m.CreatePackagesTesting(packages, licenseNumber)
+	_, err := m.PostPackagesCreateTesting(packages, licenseNumber)
 	assert.NoError(t, err)
 
 	// Get the package with the label.


### PR DESCRIPTION
This renames endpoints to front-load the action (GET, POST, PUT). This is a more ergonomic naming scheme, that's easier to use for external applications.