### PR TITLE
add items brand endpoint

### DIFF
--- a/items.go
+++ b/items.go
@@ -106,6 +106,13 @@ type ItemCategory struct {
 	CanBeRemediated              bool   `json:"CanBeRemediated"`
 }
 
+// ItemBrand represents an Item Brand in Metrc.
+// See: https://api-ca.metrc.com/Documentation/#Items.get_items_v1_brands.GET
+type ItemBrand struct {
+	Name   string `json:"Name"`
+	Status string `json:"Status"`
+}
+
 // GetItemsById gets items with an ID.
 // See: https://api-ca.metrc.com/Documentation/#Items.get_items_v1_{id}
 func (m *Metrc) GetItemsById(id int, licenseNumber *string) (ItemGet, error) {
@@ -172,6 +179,26 @@ func (m *Metrc) GetItemsCategories(licenseNumber *string) ([]ItemCategory, error
 	}
 
 	return ic, nil
+}
+
+// GetItemsBrands retrieves the brands of items for the provided license number.
+// See: https://api-ca.metrc.com/Documentation/#Items.get_items_v1_brands.GET
+func (m *Metrc) GetItemsBrands(licenseNumber string) ([]ItemBrand, error) {
+	endpoint := "items/v1/brands"
+	endpoint += fmt.Sprintf("?licenseNumber=%s", licenseNumber)
+
+	var ib []ItemBrand
+	responseBody, err := m.Client.Get(endpoint)
+	if err != nil {
+		return ib, fmt.Errorf("could not get item brands from metrc: %s", err)
+	}
+
+	err = json.Unmarshal(responseBody, &ib)
+	if err != nil {
+		return ib, fmt.Errorf("could not unmarshal response: %s", err)
+	}
+
+	return ib, nil
 }
 
 // PostItemsCreate creates new Items.

--- a/items_test.go
+++ b/items_test.go
@@ -48,6 +48,12 @@ func TestItemsGetCategories_Integration(t *testing.T) {
 	assert.True(t, foundName)
 }
 
+func TestItemsGetBrands_Integration(t *testing.T) {
+	brands, err := m.GetItemsBrands(licenseNumber)
+	assert.NoError(t, err)
+	fmt.Println(brands)
+}
+
 // Tests Create, Update, and Delete.
 // You have to GetActiveItems, find the created test item, and Update then Delete by ID.
 func TestItemsCreateUpdateDelete_Integration(t *testing.T) {


### PR DESCRIPTION
This adds the `items/v1/brand` endpoint and an associated integration test.