### PR TITLE
add location name field to plant batches

### DIFF
--- a/plantBatches.go
+++ b/plantBatches.go
@@ -12,6 +12,7 @@ type PlantBatch struct {
 	Name                 string  `json:"Name"`
 	Type                 string  `json:"Type"`
 	LocationId           *int    `json:"LocationId"`
+	LocationName         *string `json:"LocationName"`
 	LocationTypeName     *string `json:"LocationTypeName"`
 	StrainId             *int    `json:"StrainId"`
 	StrainName           *string `json:"StrainName"`


### PR DESCRIPTION
This adds a location name field to plant batches. While this field is nullable, it's particularly useful in endpoints like Move, so we do need it.